### PR TITLE
Added code so that Mink is disabled unless specifically enabled in config

### DIFF
--- a/DependencyInjection/BehatMinkExtension.php
+++ b/DependencyInjection/BehatMinkExtension.php
@@ -32,6 +32,10 @@ class BehatMinkExtension extends Extension
      */
     public function load(array $configs, ContainerBuilder $container)
     {
+        if (!$this->isMinkConfigIncluded($configs)) {
+            return;
+        }
+
         $processor      = new Processor();
         $configuration  = new Configuration();
         $config         = $processor->processConfiguration($configuration, $configs);
@@ -59,6 +63,23 @@ class BehatMinkExtension extends Extension
         $minkReflection = new \ReflectionClass('Behat\Mink\Mink');
         $minkLibPath    = realpath(dirname($minkReflection->getFilename()) . '/../../../');
         $container->setParameter('mink.paths.lib', $minkLibPath);
+    }
+
+    /**
+     * Whether or not any mink config was included.
+     *
+     * Used so that if mink isn't specifically enabled in the config, it's
+     * not loaded at all.
+     */
+    private function isMinkConfigIncluded(array $configs)
+    {
+        foreach ($configs as $config) {
+            if (!empty($config)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**


### PR DESCRIPTION
Hello!

Basically, you probably only really want mink in some test environment. Therefore, you should probably put the config in `config_test.yml`. Prior to this patch, however, Mink's Configuration validation would throw an exception in every other environment because it was missing required config. This effectively disables mink by default, and only enables it if explicitly contains mink configuration.

The only potential downside is that users won't immediately receive a validation exception when installing Mink - they'll need to follow the directions to set it up correctly.

Thanks!
