### PR TITLE
Fixed the service and parameter names

### DIFF
--- a/Resources/config/mink.xml
+++ b/Resources/config/mink.xml
@@ -25,14 +25,14 @@
         <service id="behat.mink.session.symfony" class="%behat.mink.session.class%" scope="prototype">
             <argument type="service">
                 <service class="%behat.mink.driver.symfony.class%" scope="prototype">
-                    <argument type="service" id="behat.test_client" />
+                    <argument type="service" id="behat.mink.test_client" />
                 </service>
             </argument>
             <argument type="service" id="behat.mink.selectors_handler" />
             <tag name="behat.mink.session" alias="symfony" />
         </service>
 
-        <service id="behat.test_client" class="%behat.test_client.class%"
+        <service id="behat.mink.test_client" class="%behat.test_client.class%"
             scope="prototype">
             <argument type="service" id="kernel" />
             <argument>%test.client.parameters%</argument>

--- a/Resources/config/sessions/goutte.xml
+++ b/Resources/config/sessions/goutte.xml
@@ -5,9 +5,9 @@
     <parameters>
 
         <parameter key="behat.mink.driver.goutte.class">Behat\Mink\Driver\GoutteDriver</parameter>
-        <parameter key="behat.goutte.class">Goutte\Client</parameter>
-        <parameter key="behat.goutte.zend_config" type="collection"></parameter>
-        <parameter key="behat.goutte.server_parameters" type="collection"></parameter>
+        <parameter key="behat.mink.goutte.class">Goutte\Client</parameter>
+        <parameter key="behat.mink.goutte.zend_config" type="collection"></parameter>
+        <parameter key="behat.mink.goutte.server_parameters" type="collection"></parameter>
 
     </parameters>
     <services>
@@ -15,17 +15,17 @@
         <service id="behat.mink.session.goutte" class="%behat.mink.session.class%" scope="prototype">
             <argument type="service">
                 <service class="%behat.mink.driver.goutte.class%" scope="prototype">
-                    <argument type="service" id="behat.goutte" />
+                    <argument type="service" id="behat.mink.goutte" />
                 </service>
             </argument>
             <argument type="service" id="behat.mink.selectors_handler" />
             <tag name="behat.mink.session" alias="goutte" />
         </service>
 
-        <service id="behat.goutte" class="%behat.goutte.class%"
+        <service id="behat.mink.goutte" class="%behat.mink.goutte.class%"
             scope="prototype">
-            <argument>%behat.goutte.zend_config%</argument>
-            <argument>%behat.goutte.server_parameters%</argument>
+            <argument>%behat.mink.goutte.zend_config%</argument>
+            <argument>%behat.mink.goutte.server_parameters%</argument>
         </service>
 
     </services>

--- a/Resources/config/sessions/sahi.xml
+++ b/Resources/config/sessions/sahi.xml
@@ -5,12 +5,12 @@
     <parameters>
 
         <parameter key="behat.mink.driver.sahi.class">Behat\Mink\Driver\SahiDriver</parameter>
-        <parameter key="behat.sahi.class">Behat\SahiClient\Client</parameter>
-        <parameter key="behat.sahi.connection.class">Behat\SahiClient\Connection</parameter>
+        <parameter key="behat.mink.sahi.class">Behat\SahiClient\Client</parameter>
+        <parameter key="behat.mink.sahi.connection.class">Behat\SahiClient\Connection</parameter>
 
-        <parameter key="behat.sahi.sid">null</parameter>
-        <parameter key="behat.sahi.host">localhost</parameter>
-        <parameter key="behat.sahi.port">9999</parameter>
+        <parameter key="behat.mink.sahi.sid">null</parameter>
+        <parameter key="behat.mink.sahi.host">localhost</parameter>
+        <parameter key="behat.mink.sahi.port">9999</parameter>
 
     </parameters>
     <services>
@@ -19,19 +19,19 @@
             <argument type="service">
                 <service class="%behat.mink.driver.sahi.class%" scope="prototype">
                     <argument>%behat.mink.browser_name%</argument>
-                    <argument type="service" id="behat.sahi" />
+                    <argument type="service" id="behat.mink.sahi" />
                 </service>
             </argument>
             <argument type="service" id="behat.mink.selectors_handler" />
             <tag name="behat.mink.session" alias="sahi" />
         </service>
 
-        <service id="behat.sahi" class="%behat.sahi.class%" scope="prototype">
+        <service id="behat.mink.sahi" class="%behat.mink.sahi.class%" scope="prototype">
             <argument type="service">
-                <service class="%behat.sahi.connection.class%" scope="prototype">
-                    <argument>%behat.sahi.sid%</argument>
-                    <argument>%behat.sahi.host%</argument>
-                    <argument>%behat.sahi.port%</argument>
+                <service class="%behat.mink.sahi.connection.class%" scope="prototype">
+                    <argument>%behat.mink.sahi.sid%</argument>
+                    <argument>%behat.mink.sahi.host%</argument>
+                    <argument>%behat.mink.sahi.port%</argument>
                 </service>
             </argument>
         </service>


### PR DESCRIPTION
I did the change for all services and parameters that were prefixed by `behat.` instead of `behat.mink` for consistency. The real fix concerns the parameter that are configurable through the config for Goutte and Sahi: the DI extension was setting the parameters with `behat.mink` which were not used in the service definitions, so making them not configurable.
