### PR TITLE
Replaced hardcoded kernel parameters in SymfonyDriver

### DIFF
--- a/Driver/SymfonyDriver.php
+++ b/Driver/SymfonyDriver.php
@@ -31,7 +31,7 @@ class SymfonyDriver extends GoutteDriver
     {
         // create new kernel, that could be easily rebooted
         $class  = get_class($client->getKernel());
-        $kernel = new $class('test', true);
+        $kernel = new $class($client->getKernel()->getEnvironment(), $client->getKernel()->isDebug());
         $kernel->boot();
 
         parent::__construct($kernel->getContainer()->get('test.client'));


### PR DESCRIPTION
So that the kernel will use the same environment as the test client.
