### PR TITLE
Added SymfonyDriver#getResponseHeaders

### DIFF
--- a/Driver/SymfonyDriver.php
+++ b/Driver/SymfonyDriver.php
@@ -104,6 +104,28 @@ class SymfonyDriver extends GoutteDriver
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function getResponseHeaders()
+    {
+        $headers         = array();
+        $responseHeaders = trim($this->getClient()->getResponse()->headers->__toString());
+
+        foreach (explode("\r\n", $responseHeaders) as $header) {
+            list($name, $value) = array_map('trim', explode(':', $header));
+
+            if (isset($headers[$name])) {
+                $headers[$name]   = array($headers[$name]);
+                $headers[$name][] = $value;
+            } else {
+                $headers[$name] = $value;
+            }
+        }
+
+        return $headers;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function getStatusCode()


### PR DESCRIPTION
It happens that when in a symfony2 context, the client used is
FrameworkBundle\Client, which differs from the Goutte\Client by the Response
object it uses (HttpFoundation\Response instead of BrowserKit\Response).
Unfortunately, those 2 response objects are not compatible.

This implementation might look a bit messy, but sf components' HeaderBag does
not provide a clean way to retrieve headers in the format we want.
