### PR TITLE
Fixed header parsing for Symfony driver.

### DIFF
--- a/Driver/SymfonyDriver.php
+++ b/Driver/SymfonyDriver.php
@@ -112,7 +112,7 @@ class SymfonyDriver extends GoutteDriver
         $responseHeaders = trim($this->getClient()->getResponse()->headers->__toString());
 
         foreach (explode("\r\n", $responseHeaders) as $header) {
-            list($name, $value) = array_map('trim', explode(':', $header));
+            list($name, $value) = array_map('trim', explode(':', $header, 2));
 
             if (isset($headers[$name])) {
                 $headers[$name]   = array($headers[$name]);


### PR DESCRIPTION
If there was a colon in a header it was parsed incorrectly. 

For example if there was a full URL in a location header "http" was returned instead of "http://www.example.org/".
