### PR TITLE
added TestSessionListenerPass

### DIFF
--- a/DependencyInjection/Compiler/TestSessionListenerPass.php
+++ b/DependencyInjection/Compiler/TestSessionListenerPass.php
@@ -23,9 +23,7 @@ class TestSessionListenerPass implements CompilerPassInterface
 {
     public function process(ContainerBuilder $container)
     {
-        if ('test' === $container->getParameterBag()->get('kernel.environment')) {
-            $sessionListenerClass = $container->getParameter('session_listener.class');
-            $container->setParameter('test.session.listener.class', $sessionListenerClass);
-        }
+        $sessionListenerClass = $container->getParameter('session_listener.class');
+        $container->setParameter('test.session.listener.class', $sessionListenerClass);
     }
 }

--- a/MinkBundle.php
+++ b/MinkBundle.php
@@ -36,6 +36,8 @@ class MinkBundle extends Bundle
 
         $container->addCompilerPass(new SessionsPass());
         $container->addCompilerPass(new SelectorsHandlerPass());
-        $container->addCompilerPass(new TestSessionListenerPass());
+        if ('test' === $container->getParameterBag()->get('kernel.environment')) {
+            $container->addCompilerPass(new TestSessionListenerPass());
+        }
     }
 }


### PR DESCRIPTION
This dependency injection compiler pass, replaces [test session listener](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/EventListener/TestSessionListener.php) for real [session listener](https://github.com/symfony/symfony/blob/master/src/Symfony/Bundle/FrameworkBundle/EventListener/SessionListener.php). To provide ability to `Different Browsers - Drivers` such as Sahi, Zombie.js, etc. set session cookies.
