### PR TITLE
add profile support for selenium2 when using firefox

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -112,6 +112,13 @@ class Configuration implements ConfigurationInterface
                                 scalarNode('browserName')->
                                     defaultValue('%mink.browser_name%')->
                                 end()->
+                                arrayNode('firefox')->
+                                    children()->
+                                        scalarNode('profile')->
+                                            defaultNull()->
+                                        end()->
+                                    end()->
+                                end()->
                             end()->
                         end()->
                         scalarNode('wd_host')->


### PR DESCRIPTION
Logic is already available in MinkSelenium2Bundle but could not be set via config.
With setting profile you can:
- use a mobile user agent
- use preconfigured firefox extensions
- etc.

see also: https://github.com/Behat/MinkSelenium2Driver/blob/master/src/Behat/Mink/Driver/Selenium2Driver.php
line 99

PS: I'm not serious about line 118
defaultNull()->
