### PR TITLE
Changes getKernel to be a static function

### DIFF
--- a/Test/MinkTestCase.php
+++ b/Test/MinkTestCase.php
@@ -82,7 +82,7 @@ abstract class MinkTestCase extends WebTestCase
     /**
      * @return \Symfony\Component\HttpKernel\Kernel
      */
-    public function getKernel()
+    public static function getKernel()
     {
         if (null === static::$kernel) {
             static::$kernel = static::createKernel();


### PR DESCRIPTION
`MinkTestCase::getKernel` should be a static function as `WebTestCase::createKernel` is. The whole chain to get the kernel should be static as it's dealing with a static member of the class.
Otherwise calling `getKernel` from a static environment requires to use error suppression to suppress the warnings.
